### PR TITLE
feat: Window swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,25 @@ require("winshift").setup({
     cursorline = false,
     cursorcolumn = false,
     colorcolumn = "",
-  }
+  },
+  -- The window picker is used to select a window while swapping windows with
+  -- ':WinShift swap'.
+  -- A string of chars used as identifiers by the window picker.
+  window_picker_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+  window_picker_ignore = {
+    -- This table allows you to indicate to the window picker that a window
+    -- should be ignored if its buffer matches any of the following criteria.
+    filetype = {  -- List of ignored file types
+      "NvimTree",
+    },
+    buftype = {   -- List of ignored buftypes
+      "terminal",
+      "quickfix",
+    },
+    bufname = {   -- List of regex patterns matching ignored buffer names
+      [[.*foo/bar/baz\.qux]]
+    },
+  },
 })
 ```
 
@@ -58,6 +76,9 @@ Optionally create some mappings for starting Win-Move mode:
 " Start Win-Move mode:
 nnoremap <C-W><C-M> <Cmd>WinShift<CR>
 nnoremap <C-W>m <Cmd>WinShift<CR>
+
+" Swap two windows:
+nnoremap <C-W>X <Cmd>WinShift swap<CR>
 
 " If you don't want to use Win-Move mode you can create mappings for calling the
 " move commands directly:
@@ -84,6 +105,13 @@ moving it in the given direction. `[direction]` can be one of:
 
 The `far_` variants will move the window to the far
 end of the viewport in the given direction.
+
+### `:WinShift swap`
+
+Swap the current window with another. When this command is called, you'll be
+prompted to select the window you want to swap with. A selection is made by
+pressing the character displayed in the statusline of the target window. The
+input is case-insensitive.
 
 ## Caveats
 

--- a/doc/winshift.txt
+++ b/doc/winshift.txt
@@ -54,6 +54,13 @@ COMMANDS                                                   *winshift-commands*
                         The `far_` variants will move the window to the far
                         end of the viewport in the given direction.
 
+:WinShift swap
+                        Swap the current window with another. When this
+                        command is called, you'll be prompted to select the
+                        window you want to swap with. A selection is made by
+                        pressing the character displayed in the statusline of
+                        the target window. The input is case-insensitive.
+
 CAVEATS                                                     *winshift-caveats*
 
 Moving through windows with 'winfixwidth' and / or 'winfixheight' can be a bit

--- a/lua/winshift.lua
+++ b/lua/winshift.lua
@@ -31,6 +31,7 @@ local completion_dir = {
   "far_right",
   "far_up",
   "far_down",
+  "swap",
 }
 
 function M.setup(user_config)
@@ -40,7 +41,11 @@ end
 function M.cmd_winshift(dir)
   if dir then
     if not vim.tbl_contains(completion_dir, dir) then
-      utils.err("Direction must be one of: " .. table.concat(completion_dir, ", "))
+      utils.err("Action must be one of: " .. table.concat(completion_dir, ", "))
+      return
+    end
+    if dir == "swap" then
+      lib.start_swap_mode()
       return
     end
     lib.move_win(api.nvim_get_current_win(), dir)

--- a/lua/winshift/colors.lua
+++ b/lua/winshift/colors.lua
@@ -86,6 +86,7 @@ function M.get_hl_groups()
     CursorLineNr = { fg = M.get_fg("CursorLineNr"), bg = focused_bg, gui = M.get_gui("CursorLineNr") },
     SignColumn = { fg = M.get_fg("SignColumn"), bg = focused_bg },
     FoldColumn = { fg = M.get_fg("FoldColumn"), bg = focused_bg },
+    WindowPicker = { fg = "#ededed", bg = "#4493c8", gui = "bold" },
   }
 end
 

--- a/lua/winshift/config.lua
+++ b/lua/winshift/config.lua
@@ -10,7 +10,13 @@ M.defaults = {
     cursorline = false,
     cursorcolumn = false,
     colorcolumn = "",
-  }
+  },
+  window_picker_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+  window_picker_ignore = {
+    filetype = {},
+    buftype = {},
+    bufname = {},
+  },
 }
 -- stylua: ignore end
 

--- a/lua/winshift/utils.lua
+++ b/lua/winshift/utils.lua
@@ -163,10 +163,11 @@ function M.input_char(prompt, opt)
   opt = vim.tbl_extend("keep", opt or {}, {
     clear_prompt = true,
     allow_non_ascii = false,
+    prompt_hl = nil,
   })
 
   if prompt then
-    vim.api.nvim_echo({ { prompt } }, false, {})
+    vim.api.nvim_echo({ { prompt, opt.prompt_hl } }, false, {})
   end
 
   local c
@@ -205,32 +206,50 @@ end
 ---HACK: workaround for inconsistent behavior from `vim.opt_local`.
 ---@see [Neovim issue](https://github.com/neovim/neovim/issues/14670)
 ---@param winids number[]|number Either a list of winids, or a single winid (0 for current window).
----@param option string
----@param value string[]|string
----@param opt table
 ---`opt` fields:
----   - `method` '"set"'|'"remove"'|'"append"'|'"prepend"' Assignment method. (default: "set")
-function M.set_local(winids, option, value, opt)
-  local cmd
-  opt = vim.tbl_extend("keep", opt or {}, {
-    method = "set",
-  })
-
-  if type(value) == "boolean" then
-    cmd = string.format("setl %s%s", value and "" or "no", option)
-  else
-    value = (type(value) == "table" and table.concat(value, ",") or tostring(value)):gsub("'", "''")
-    cmd = M.str_template(setlocal_opr_templates[opt.method], { option = option, value = value })
-  end
-
+---   @tfield method '"set"'|'"remove"'|'"append"'|'"prepend"' Assignment method. (default: "set")
+---@overload fun(winids: number[]|number, option: string, value: string[]|string|boolean, opt?: any)
+---@overload fun(winids: number[]|number, map: table<string, string[]|string|boolean>, opt?: table)
+function M.set_local(winids, x, y, z)
   if type(winids) ~= "table" then
     winids = { winids }
   end
 
+  local map, opt
+  if y == nil or type(y) == "table" then
+    map = x
+    opt = y
+  else
+    map = { [x] = y }
+    opt = z
+  end
+
+  opt = vim.tbl_extend("keep", opt or {}, { method = "set" })
+
+  local cmd
   local ok, err = M.no_win_event_call(function()
     for _, id in ipairs(winids) do
       api.nvim_win_call(id, function()
-        vim.cmd(cmd)
+        for option, value in pairs(map) do
+          local o = opt
+
+          if type(value) == "boolean" then
+            cmd = string.format("setl %s%s", value and "" or "no", option)
+          else
+            if type(value) == "table" then
+              ---@diagnostic disable-next-line: undefined-field
+              o = vim.tbl_extend("force", opt, value.opt or {})
+              value = table.concat(value, ",")
+            end
+
+            cmd = M.str_template(
+              setlocal_opr_templates[o.method],
+              { option = option, value = tostring(value):gsub("'", "''") }
+            )
+          end
+
+          vim.cmd(cmd)
+        end
       end)
     end
   end)
@@ -242,23 +261,16 @@ end
 
 ---@param winids number[]|number Either a list of winids, or a single winid (0 for current window).
 ---@param option string
----@param opt table
-function M.unset_local(winids, option, opt)
-  local last_winid = api.nvim_get_current_win()
-  opt = vim.tbl_extend("keep", opt or {}, { restore_cursor = true })
-
+function M.unset_local(winids, option)
   if type(winids) ~= "table" then
     winids = { winids }
   end
 
   M.no_win_event_call(function()
     for _, id in ipairs(winids) do
-      local nr = tostring(api.nvim_win_get_number(id == 0 and last_winid or id))
-      vim.cmd(string.format("%swindo set %s<", nr, option))
-    end
-
-    if opt.restore_cursor then
-      api.nvim_set_current_win(last_winid)
+      api.nvim_win_call(id, function()
+        vim.cmd(string.format("set %s<", option))
+      end)
     end
   end)
 end


### PR DESCRIPTION
This implements a new operation: `:WinShift swap`, that lets you swap the current window with another target window.

```vimhelp
:WinShift swap
                        Swap the current window with another. When this
                        command is called, you'll be prompted to select the
                        window you want to swap with. A selection is made by
                        pressing the character displayed in the statusline of
                        the target window. The input is case-insensitive.
```

![Peek 2021-11-07 12-59](https://user-images.githubusercontent.com/2786478/140644022-7eaa50cf-ee6a-4c5e-bfda-c011f588f505.gif)